### PR TITLE
fix: don't use base tsconfig in shared package

### DIFF
--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,3 +1,36 @@
 {
-  "extends": "tsconfig/base"
+  "compilerOptions": {
+    // Strict Checks
+    "alwaysStrict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "useUnknownInCatchVariables": true,
+    "strictPropertyInitialization": true,
+    "strictFunctionTypes": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    // Linter Checks
+    "noImplicitReturns": true,
+    "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
+    // https://eslint.org/docs/rules/consistent-return ?
+    "noFallthroughCasesInSwitch": true,
+    // https://eslint.org/docs/rules/no-fallthrough
+    "noUnusedLocals": true,
+    // https://eslint.org/docs/rules/no-unused-vars
+    "noUnusedParameters": true,
+    // https://eslint.org/docs/rules/no-unused-vars#args
+    "allowUnreachableCode": false,
+    // https://eslint.org/docs/rules/no-unreachable ?
+    "allowUnusedLabels": false,
+    // https://eslint.org/docs/rules/no-unused-labels
+    // Base Strict Checks
+    "noImplicitUseStrict": false,
+    "suppressExcessPropertyErrors": false,
+    "suppressImplicitAnyIndexErrors": false,
+    "noStrictGenericChecks": false
+  }
 }


### PR DESCRIPTION
don't use base `tsconfig` in `shared` package as it fails the build for `admin`app