### PR TITLE
Update Sentry config and simplify docker-compose

### DIFF
--- a/apps/admin/src/hooks.client.ts
+++ b/apps/admin/src/hooks.client.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/sveltekit'
 import type { HandleClientError } from '@sveltejs/kit'
 
 Sentry.init({
+  enabled: import.meta.env.PROD,
   dsn: 'https://2fa0f5212da27f8a385d59ee059814bc@o4507650143748096.ingest.us.sentry.io/4509004455149568',
   environment: import.meta.env.PROD ? 'production' : 'development',
   tracesSampleRate: 0.1,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,44 +1,4 @@
 services:
-  gov:
-    build:
-      context: .
-      dockerfile: ./apps/gov/Dockerfile
-      args:
-        - 'API_URL=${API_URL}'
-    restart: always
-    ports:
-      - 8080:4321
-    depends_on:
-      api:
-        condition: service_healthy
-  admin:
-    build:
-      context: .
-      dockerfile: ./apps/admin/Dockerfile
-      args:
-        - PUBLIC_API_URL=${PUBLIC_API_URL}
-    ports:
-      - 8082:80
-    depends_on:
-      api:
-        condition: service_healthy
-  api:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-    env_file: .env
-    ports:
-      - 8000:8000
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    healthcheck:
-      test: ['CMD', 'curl', '-f', 'http://localhost:8000/v1/healthcheck']
-      interval: 10s
-      timeout: 5s
-      retries: 3
   db:
     image: postgres:alpine
     restart: always


### PR DESCRIPTION
Summary of changes:
- Enabled Sentry only in production environment in apps/admin/src/hooks.client.ts
- Removed multiple services from docker-compose.dev.yml, leaving only db and redis services configuration