### PR TITLE
admin: phosphor icon exports without `Icon` suffix are deprecated

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -6,7 +6,7 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && node --test src/lib/publications/*.test.mjs",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint \"src/**/*.{js,svelte,ts}\"",
     "clean": "rm -rf ./.turbo && rm -rf ./.svelte-kit && rm -rf ./build",

--- a/apps/admin/src/lib/components/AssetDialog.svelte
+++ b/apps/admin/src/lib/components/AssetDialog.svelte
@@ -10,9 +10,9 @@
   import InputGroup from './InputGroup.svelte'
   import Select from './Select.svelte'
   import SelectOption from './SelectOption.svelte'
-  import ArrowUp from 'phosphor-svelte/lib/ArrowUp'
-  import ArrowDown from 'phosphor-svelte/lib/ArrowDown'
-  import MagnifyingGlass from 'phosphor-svelte/lib/MagnifyingGlass'
+  import ArrowUpIcon from 'phosphor-svelte/lib/ArrowUpIcon'
+  import ArrowDownIcon from 'phosphor-svelte/lib/ArrowDownIcon'
+  import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlassIcon'
   import { useIntersect } from '$lib/use-intersect.svelte'
   import { useAssets } from '$lib/assets/query'
   import { DEFAULT_SORT_OPTION, sortOptions } from '$lib/select-options'
@@ -81,7 +81,7 @@
       <div class="flex max-w-2xl flex-col gap-5 sm:flex-1 sm:flex-row">
         <div class="flex-1">
           <InputGroup>
-            <MagnifyingGlass weight="regular" />
+            <MagnifyingGlassIcon weight="regular" />
             <Input
               placeholder="Пошук&hellip;"
               oninput={handleSearch}
@@ -102,9 +102,9 @@
               <SelectOption value={key} label={value.label}>
                 {#snippet icon()}
                   {#if value.order === 'asc'}
-                    <ArrowUp weight="fill" />
+                    <ArrowUpIcon weight="fill" />
                   {:else}
-                    <ArrowDown weight="fill" />
+                    <ArrowDownIcon weight="fill" />
                   {/if}
                 {/snippet}
                 {value.label}

--- a/apps/admin/src/lib/components/AssetItem.svelte
+++ b/apps/admin/src/lib/components/AssetItem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import VideoCamera from 'phosphor-svelte/lib/VideoCamera'
-  import FileText from 'phosphor-svelte/lib/FileText'
+  import VideoCameraIcon from 'phosphor-svelte/lib/VideoCameraIcon'
+  import FileTextIcon from 'phosphor-svelte/lib/FileTextIcon'
 
   type Props = {
     contentType: string
@@ -28,9 +28,9 @@
           class="!max-h-full !max-w-full"
         />
       {:else if contentType.startsWith('video')}
-        <VideoCamera class="h-12 w-12 text-amber-400 lg:h-16 lg:w-16" />
+        <VideoCameraIcon class="h-12 w-12 text-amber-400 lg:h-16 lg:w-16" />
       {:else}
-        <FileText class="h-12 w-12 text-blue-400 lg:h-16 lg:w-16" />
+        <FileTextIcon class="h-12 w-12 text-blue-400 lg:h-16 lg:w-16" />
       {/if}
     </div>
   </div>

--- a/apps/admin/src/lib/components/Combobox.svelte
+++ b/apps/admin/src/lib/components/Combobox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" generics="T">
   import { Combobox } from 'bits-ui'
-  import CaretUpDown from 'phosphor-svelte/lib/CaretUpDown'
+  import CaretUpDownIcon from 'phosphor-svelte/lib/CaretUpDownIcon'
   import type { Snippet } from 'svelte'
   import { setComboboxContext } from '$lib/context'
 
@@ -89,7 +89,7 @@
       class="group absolute inset-y-0 right-0 flex items-center px-2"
       type="button"
     >
-      <CaretUpDown
+      <CaretUpDownIcon
         class="size-5 stroke-zinc-500 group-data-disabled:stroke-zinc-600 group-data-hover:stroke-zinc-700 sm:size-4"
       />
     </Combobox.Trigger>

--- a/apps/admin/src/lib/components/ComboboxOption.svelte
+++ b/apps/admin/src/lib/components/ComboboxOption.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" generics="T">
   import { getComboboxContext } from '$lib/context'
   import { Combobox as ComboboxPrimitive } from 'bits-ui'
-  import Check from 'phosphor-svelte/lib/Check'
+  import CheckIcon from 'phosphor-svelte/lib/CheckIcon'
   import type { Snippet } from 'svelte'
 
   interface Props {
@@ -30,7 +30,7 @@
 >
   {#snippet children({ selected })}
     {#if selected}
-      <Check
+      <CheckIcon
         size={20}
         weight="regular"
         class="relative size-5 self-center text-current sm:size-4"

--- a/apps/admin/src/lib/components/ContentCard.svelte
+++ b/apps/admin/src/lib/components/ContentCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import PlusCircle from 'phosphor-svelte/lib/PlusCircle'
-  import ArrowUpLeft from 'phosphor-svelte/lib/ArrowUpLeft'
+  import PlusCircleIcon from 'phosphor-svelte/lib/PlusCircleIcon'
+  import ArrowUpLeftIcon from 'phosphor-svelte/lib/ArrowUpLeftIcon'
   import type { Snippet } from 'svelte'
 
   type Props = {
@@ -34,7 +34,7 @@
         {href}
         class="flex items-center justify-center gap-1.5 rounded-bl-md py-4 text-sm font-semibold hover:bg-gray-50"
       >
-        <ArrowUpLeft class="size-5 text-gray-400" />
+        <ArrowUpLeftIcon class="size-5 text-gray-400" />
         <span>Переглянути</span>
       </a>
     </div>
@@ -44,7 +44,7 @@
           href={createHref}
           class="flex items-center justify-center gap-1.5 rounded-br-md py-4 text-sm font-semibold hover:bg-gray-50"
         >
-          <PlusCircle class="size-5 text-gray-400" />
+          <PlusCircleIcon class="size-5 text-gray-400" />
           <span>Створити</span>
         </a>
       </div>

--- a/apps/admin/src/lib/components/CoverSelect.svelte
+++ b/apps/admin/src/lib/components/CoverSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import Image from 'phosphor-svelte/lib/Image'
-  import Plus from 'phosphor-svelte/lib/Plus'
+  import ImageIcon from 'phosphor-svelte/lib/ImageIcon'
+  import PlusIcon from 'phosphor-svelte/lib/PlusIcon'
   import AssetDialog from './AssetDialog.svelte'
   import { AssetSchema } from '@babyn-yar/schema'
 
@@ -47,14 +47,14 @@
           class="h-full max-w-full object-contain"
         />
       {:else}
-        <Image class="size-6" />
+        <ImageIcon class="size-6" />
       {/if}
     </div>
     <div class="flex items-center gap-1">
       {#if cover}
         <span class="text-sm"> Змінити </span>
       {:else}
-        <Plus class="size-4" />
+        <PlusIcon class="size-4" />
         <p class="text-sm">Додати обкладинку</p>
       {/if}
     </div>

--- a/apps/admin/src/lib/components/DatePickerCalendar.svelte
+++ b/apps/admin/src/lib/components/DatePickerCalendar.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { DatePicker } from 'bits-ui'
-  import CaretLeft from 'phosphor-svelte/lib/CaretLeft'
-  import CaretRight from 'phosphor-svelte/lib/CaretRight'
-  import CalendarBlank from 'phosphor-svelte/lib/CalendarBlank'
+  import CaretLeftIcon from 'phosphor-svelte/lib/CaretLeftIcon'
+  import CaretRightIcon from 'phosphor-svelte/lib/CaretRightIcon'
+  import CalendarBlankIcon from 'phosphor-svelte/lib/CalendarBlankIcon'
   import Button from './Button.svelte'
   import type { DateValue } from '@internationalized/date'
   import { jsDateToCalendarDate } from '$lib/format-date'
@@ -59,7 +59,7 @@
       class="group absolute inset-y-0 right-0 flex items-center px-2 outline-none"
       type="button"
     >
-      <CalendarBlank
+      <CalendarBlankIcon
         class="size-5 text-zinc-500 group-hover:text-zinc-700 sm:size-4"
       />
     </DatePicker.Trigger>
@@ -79,7 +79,7 @@
               {#snippet child({ props })}
                 <Button plain {...props}>
                   {#snippet icon()}
-                    <CaretLeft />
+                    <CaretLeftIcon />
                   {/snippet}
                 </Button>
               {/snippet}
@@ -89,7 +89,7 @@
               {#snippet child({ props })}
                 <Button plain {...props}>
                   {#snippet icon()}
-                    <CaretRight />
+                    <CaretRightIcon />
                   {/snippet}
                 </Button>
               {/snippet}

--- a/apps/admin/src/lib/components/DocumentsSelect.svelte
+++ b/apps/admin/src/lib/components/DocumentsSelect.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import X from 'phosphor-svelte/lib/X'
-  import Plus from 'phosphor-svelte/lib/Plus'
+  import XIcon from 'phosphor-svelte/lib/XIcon'
+  import PlusIcon from 'phosphor-svelte/lib/PlusIcon'
   import AssetDialog from './AssetDialog.svelte'
   import { AssetSchema } from '@babyn-yar/schema'
 
@@ -60,7 +60,7 @@
           aria-label="Видалити долучення"
           {disabled}
         >
-          <X class="size-4" />
+          <XIcon class="size-4" />
         </button>
       </div>
     {/each}
@@ -71,7 +71,7 @@
       class="flex items-center gap-1 rounded px-2 py-1 text-sm text-gray-700 hover:bg-zinc-950/5 focus:outline-hidden"
       onclick={handleOpenDialog}
     >
-      <Plus class="size-4" />
+      <PlusIcon class="size-4" />
       <span>Додати</span>
     </button>
   </div>

--- a/apps/admin/src/lib/components/ErrorMessage.svelte
+++ b/apps/admin/src/lib/components/ErrorMessage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte'
-  import Warning from 'phosphor-svelte/lib/Warning'
+  import WarningIcon from 'phosphor-svelte/lib/WarningIcon'
 
   type Props = {
     children: Snippet
@@ -13,7 +13,7 @@
   <div
     class="flex gap-3 rounded border border-red-700/10 bg-red-100 px-4 py-2.5 text-red-800"
   >
-    <Warning />
+    <WarningIcon />
     <span>
       {@render children()}
     </span>

--- a/apps/admin/src/lib/components/FileListItem.svelte
+++ b/apps/admin/src/lib/components/FileListItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import Trash from 'phosphor-svelte/lib/Trash'
-  import VideoCamera from 'phosphor-svelte/lib/VideoCamera'
-  import FileText from 'phosphor-svelte/lib/FileText'
+  import TrashIcon from 'phosphor-svelte/lib/TrashIcon'
+  import VideoCameraIcon from 'phosphor-svelte/lib/VideoCameraIcon'
+  import FileTextIcon from 'phosphor-svelte/lib/FileTextIcon'
 
   type Props = {
     file: File
@@ -40,7 +40,7 @@
     class="absolute top-3 right-3 z-10 hidden items-center justify-center p-1.5 text-gray-400 group-hover:inline-flex hover:text-red-400"
     aria-label="Видалити файл"
   >
-    <Trash size={16} />
+    <TrashIcon size={16} />
   </button>
   <div
     class="flex h-[160px] items-center justify-center overflow-hidden rounded-lg bg-gray-100"
@@ -52,9 +52,9 @@
         class="max-h-full w-full object-cover"
       />
     {:else if fileType === 'video'}
-      <VideoCamera class="h-12 w-12 text-amber-400 lg:h-16 lg:w-16" />
+      <VideoCameraIcon class="h-12 w-12 text-amber-400 lg:h-16 lg:w-16" />
     {:else}
-      <FileText class="h-12 w-12 text-blue-400 lg:h-16  lg:w-16" />
+      <FileTextIcon class="h-12 w-12 text-blue-400 lg:h-16  lg:w-16" />
     {/if}
   </div>
   <div class="w-full">

--- a/apps/admin/src/lib/components/LinkDialog.svelte
+++ b/apps/admin/src/lib/components/LinkDialog.svelte
@@ -11,9 +11,9 @@
   import Input from './Input.svelte'
   import Select from './Select.svelte'
   import SelectOption from './SelectOption.svelte'
-  import Link from 'phosphor-svelte/lib/Link'
-  import Globe from 'phosphor-svelte/lib/Globe'
-  import At from 'phosphor-svelte/lib/At'
+  import LinkIcon from 'phosphor-svelte/lib/LinkIcon'
+  import GlobeIcon from 'phosphor-svelte/lib/GlobeIcon'
+  import AtIcon from 'phosphor-svelte/lib/AtIcon'
 
   type Props = {
     open: boolean
@@ -35,17 +35,17 @@
     {
       label: 'Internal',
       value: 'internal',
-      Icon: Link
+      Icon: LinkIcon
     },
     {
       label: 'URL',
       value: 'external',
-      Icon: Globe
+      Icon: GlobeIcon
     },
     {
       label: 'Email',
       value: 'email',
-      Icon: At
+      Icon: AtIcon
     }
   ]
 </script>

--- a/apps/admin/src/lib/components/MobileDrawer.svelte
+++ b/apps/admin/src/lib/components/MobileDrawer.svelte
@@ -3,8 +3,8 @@
   import { fade, fly } from 'svelte/transition'
   import Sidebar from './Sidebar.svelte'
   import Button from './Button.svelte'
-  import List from 'phosphor-svelte/lib/List'
-  import X from 'phosphor-svelte/lib/X'
+  import ListIcon from 'phosphor-svelte/lib/ListIcon'
+  import XIcon from 'phosphor-svelte/lib/XIcon'
   import { mobileDrawer } from '$lib/state.svelte'
 </script>
 
@@ -17,7 +17,7 @@
     {#snippet child({ props })}
       <Button plain {...props}>
         {#snippet icon()}
-          <List />
+          <ListIcon />
         {/snippet}
       </Button>
     {/snippet}
@@ -54,7 +54,7 @@
                   {#snippet child({ props })}
                     <Button plain aria-label="Close" {...props}>
                       {#snippet icon()}
-                        <X />
+                        <XIcon />
                       {/snippet}
                     </Button>
                   {/snippet}

--- a/apps/admin/src/lib/components/PaginationNext.svelte
+++ b/apps/admin/src/lib/components/PaginationNext.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Pagination } from 'bits-ui'
-  import ArrowRight from 'phosphor-svelte/lib/ArrowRight'
+  import ArrowRightIcon from 'phosphor-svelte/lib/ArrowRightIcon'
 </script>
 
 <div class="flex grow basis-0 justify-end">
@@ -8,6 +8,6 @@
     class="relative isolate inline-flex items-baseline justify-center gap-x-2 rounded-lg border border-transparent px-3.5 py-2.5 text-base/6 font-semibold text-zinc-950 [--btn-icon:var(--color-zinc-500)] hover:bg-zinc-950/5 hover:[--btn-icon:var(--color-zinc-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:[--btn-icon:var(--color-zinc-500)] *:data-[slot=icon]:-mx-0.5 *:data-[slot=icon]:my-0.5 *:data-[slot=icon]:size-5 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:self-center *:data-[slot=icon]:text-(--btn-icon) sm:px-3 sm:py-1.5 sm:text-sm/6 sm:*:data-[slot=icon]:my-1 sm:*:data-[slot=icon]:size-4"
   >
     Наступна
-    <ArrowRight />
+    <ArrowRightIcon />
   </Pagination.NextButton>
 </div>

--- a/apps/admin/src/lib/components/PaginationPrev.svelte
+++ b/apps/admin/src/lib/components/PaginationPrev.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
   import { Pagination } from 'bits-ui'
-  import ArrowLeft from 'phosphor-svelte/lib/ArrowLeft'
+  import ArrowLeftIcon from 'phosphor-svelte/lib/ArrowLeftIcon'
 </script>
 
 <div class="grow basis-0">
   <Pagination.PrevButton
     class="relative isolate inline-flex items-baseline justify-center gap-x-2 rounded-lg border border-transparent px-3.5 py-2.5 text-base/6 font-semibold text-zinc-950 [--btn-icon:var(--color-zinc-500)] hover:bg-zinc-950/5 hover:[--btn-icon:var(--color-zinc-700)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:[--btn-icon:var(--color-zinc-500)] *:data-[slot=icon]:-mx-0.5 *:data-[slot=icon]:my-0.5 *:data-[slot=icon]:size-5 *:data-[slot=icon]:shrink-0 *:data-[slot=icon]:self-center *:data-[slot=icon]:text-(--btn-icon) sm:px-3 sm:py-1.5 sm:text-sm/6 sm:*:data-[slot=icon]:my-1 sm:*:data-[slot=icon]:size-4"
   >
-    <ArrowLeft />
+    <ArrowLeftIcon />
     Попередня
   </Pagination.PrevButton>
 </div>

--- a/apps/admin/src/lib/components/RegisterUserDialog.svelte
+++ b/apps/admin/src/lib/components/RegisterUserDialog.svelte
@@ -10,7 +10,7 @@
   import Field from './Field.svelte'
   import Label from './Label.svelte'
   import InputGroup from './InputGroup.svelte'
-  import Lock from 'phosphor-svelte/lib/Lock'
+  import LockIcon from 'phosphor-svelte/lib/LockIcon'
   import SelectOption from './SelectOption.svelte'
   import Select from './Select.svelte'
   import DialogActions from './DialogActions.svelte'
@@ -121,7 +121,7 @@
               <Label for={field.name}>Пароль</Label>
               <Description>Має бути не менше 8 символів</Description>
               <InputGroup>
-                <Lock size={20} />
+                <LockIcon size={20} />
                 <Input
                   type="password"
                   id={field.name}

--- a/apps/admin/src/lib/components/RichTextEditor.svelte
+++ b/apps/admin/src/lib/components/RichTextEditor.svelte
@@ -3,25 +3,25 @@
   import EditorCommandDivider from './EditorCommandDivider.svelte'
   import AssetDialog from './AssetDialog.svelte'
   import YouTubeLinkDialog from './YouTubeLinkDialog.svelte'
-  import TextHOne from 'phosphor-svelte/lib/TextHOne'
-  import TextHTwo from 'phosphor-svelte/lib/TextHTwo'
-  import TextHThree from 'phosphor-svelte/lib/TextHThree'
-  import Paragraph from 'phosphor-svelte/lib/Paragraph'
-  import Link from 'phosphor-svelte/lib/Link'
-  import LinkBreak from 'phosphor-svelte/lib/LinkBreak'
-  import ListBullets from 'phosphor-svelte/lib/ListBullets'
-  import ListNumbers from 'phosphor-svelte/lib/ListNumbers'
-  import TextB from 'phosphor-svelte/lib/TextB'
-  import TextItalic from 'phosphor-svelte/lib/TextItalic'
-  import TextUnderline from 'phosphor-svelte/lib/TextUnderline'
-  import TextStrikethrough from 'phosphor-svelte/lib/TextStrikethrough'
-  import TextAlignLeft from 'phosphor-svelte/lib/TextAlignLeft'
-  import TextAlignCenter from 'phosphor-svelte/lib/TextAlignCenter'
-  import TextAlignRight from 'phosphor-svelte/lib/TextAlignRight'
-  import ArrowElbowDownLeft from 'phosphor-svelte/lib/ArrowElbowDownLeft'
-  import ImageSquare from 'phosphor-svelte/lib/ImageSquare'
-  import VideoCamera from 'phosphor-svelte/lib/VideoCamera'
-  import YoutubeLogo from 'phosphor-svelte/lib/YoutubeLogo'
+  import TextHOneIcon from 'phosphor-svelte/lib/TextHOneIcon'
+  import TextHTwoIcon from 'phosphor-svelte/lib/TextHTwoIcon'
+  import TextHThreeIcon from 'phosphor-svelte/lib/TextHThreeIcon'
+  import ParagraphIcon from 'phosphor-svelte/lib/ParagraphIcon'
+  import LinkIcon from 'phosphor-svelte/lib/LinkIcon'
+  import LinkBreakIcon from 'phosphor-svelte/lib/LinkBreakIcon'
+  import ListBulletsIcon from 'phosphor-svelte/lib/ListBulletsIcon'
+  import ListNumbersIcon from 'phosphor-svelte/lib/ListNumbersIcon'
+  import TextBIcon from 'phosphor-svelte/lib/TextBIcon'
+  import TextItalicIcon from 'phosphor-svelte/lib/TextItalicIcon'
+  import TextUnderlineIcon from 'phosphor-svelte/lib/TextUnderlineIcon'
+  import TextStrikethroughIcon from 'phosphor-svelte/lib/TextStrikethroughIcon'
+  import TextAlignLeftIcon from 'phosphor-svelte/lib/TextAlignLeftIcon'
+  import TextAlignCenterIcon from 'phosphor-svelte/lib/TextAlignCenterIcon'
+  import TextAlignRightIcon from 'phosphor-svelte/lib/TextAlignRightIcon'
+  import ArrowElbowDownLeftIcon from 'phosphor-svelte/lib/ArrowElbowDownLeftIcon'
+  import ImageSquareIcon from 'phosphor-svelte/lib/ImageSquareIcon'
+  import VideoCameraIcon from 'phosphor-svelte/lib/VideoCameraIcon'
+  import YoutubeLogoIcon from 'phosphor-svelte/lib/YoutubeLogoIcon'
   import { Editor } from '@tiptap/core'
   import { extensions } from '$lib/editor-extensions'
   import { onDestroy, onMount } from 'svelte'
@@ -132,108 +132,108 @@
               editor?.chain().focus().toggleHeading({ level: 1 }).run()}
             active={editor.isActive('heading', { level: 1 })}
           >
-            <TextHOne size={16} />
+            <TextHOneIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() =>
               editor?.chain().focus().toggleHeading({ level: 2 }).run()}
             active={editor.isActive('heading', { level: 2 })}
           >
-            <TextHTwo size={16} />
+            <TextHTwoIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() =>
               editor?.chain().focus().toggleHeading({ level: 3 }).run()}
             active={editor.isActive('heading', { level: 3 })}
           >
-            <TextHThree size={16} />
+            <TextHThreeIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().setParagraph().run()}
             active={editor.isActive('paragraph')}
           >
-            <Paragraph size={16} />
+            <ParagraphIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={handleOpenLinkDialog}
             active={editor.isActive('link')}
           >
-            <Link size={16} />
+            <LinkIcon size={16} />
           </EditorCommand>
           {#if editor.isActive('link')}
             <EditorCommand
               onClick={() => editor?.chain().focus().unsetLink().run()}
             >
-              <LinkBreak size={16} />
+              <LinkBreakIcon size={16} />
             </EditorCommand>
           {/if}
           <EditorCommand
             onClick={() => editor?.chain().focus().toggleBulletList().run()}
             active={editor.isActive('bulletList')}
           >
-            <ListBullets size={16} />
+            <ListBulletsIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().toggleOrderedList().run()}
             active={editor.isActive('orderedList')}
           >
-            <ListNumbers size={16} />
+            <ListNumbersIcon size={16} />
           </EditorCommand>
           <EditorCommandDivider />
           <EditorCommand
             onClick={() => editor?.chain().focus().toggleBold().run()}
             active={editor.isActive('bold')}
           >
-            <TextB size={16} />
+            <TextBIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().toggleItalic().run()}
             active={editor.isActive('italic')}
           >
-            <TextItalic size={16} />
+            <TextItalicIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().toggleUnderline().run()}
             active={editor.isActive('underline')}
           >
-            <TextUnderline size={16} />
+            <TextUnderlineIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().toggleStrike().run()}
             active={editor.isActive('strike')}
           >
-            <TextStrikethrough size={16} />
+            <TextStrikethroughIcon size={16} />
           </EditorCommand>
           <EditorCommandDivider />
           <EditorCommand
             onClick={() => editor?.chain().focus().setTextAlign('left').run()}
           >
-            <TextAlignLeft size={16} />
+            <TextAlignLeftIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().setTextAlign('center').run()}
           >
-            <TextAlignCenter size={16} />
+            <TextAlignCenterIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().setTextAlign('right').run()}
           >
-            <TextAlignRight size={16} />
+            <TextAlignRightIcon size={16} />
           </EditorCommand>
           <EditorCommand
             onClick={() => editor?.chain().focus().setHardBreak().run()}
           >
-            <ArrowElbowDownLeft size={16} />
+            <ArrowElbowDownLeftIcon size={16} />
           </EditorCommand>
           <EditorCommandDivider />
           <EditorCommand onClick={handleOpenImageDialog}>
-            <ImageSquare size={16} />
+            <ImageSquareIcon size={16} />
           </EditorCommand>
           <EditorCommand onClick={handleOpenVideoDialog}>
-            <VideoCamera size={16} />
+            <VideoCameraIcon size={16} />
           </EditorCommand>
           <EditorCommand onClick={handleOpenYouTubeDialog}>
-            <YoutubeLogo size={16} />
+            <YoutubeLogoIcon size={16} />
           </EditorCommand>
         </div>
       </div>

--- a/apps/admin/src/lib/components/Select.svelte
+++ b/apps/admin/src/lib/components/Select.svelte
@@ -2,7 +2,7 @@
   import { cn } from '$lib/cn'
   import { getFieldContext } from '$lib/context'
   import { Select } from 'bits-ui'
-  import CaretDown from 'phosphor-svelte/lib/CaretDown'
+  import CaretDownIcon from 'phosphor-svelte/lib/CaretDownIcon'
   import type { Snippet } from 'svelte'
 
   type Props = {
@@ -79,7 +79,7 @@
     <span
       class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2"
     >
-      <CaretDown
+      <CaretDownIcon
         class="size-5 text-zinc-500 group-data-disabled:text-zinc-600 sm:size-4"
       />
     </span>

--- a/apps/admin/src/lib/components/SelectOption.svelte
+++ b/apps/admin/src/lib/components/SelectOption.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Select } from 'bits-ui'
-  import Check from 'phosphor-svelte/lib/Check'
+  import CheckIcon from 'phosphor-svelte/lib/CheckIcon'
 
   const { value, label, icon = undefined, children: kids } = $props()
 </script>
@@ -13,7 +13,7 @@
 >
   {#snippet children({ selected })}
     {#if selected}
-      <Check
+      <CheckIcon
         size={20}
         weight="regular"
         class="relative size-5 self-center text-current sm:size-4"

--- a/apps/admin/src/lib/components/Sidebar.svelte
+++ b/apps/admin/src/lib/components/Sidebar.svelte
@@ -1,9 +1,9 @@
 <script>
   import SidebarLink from './SidebarLink.svelte'
-  import Image from 'phosphor-svelte/lib/Image'
-  import Files from 'phosphor-svelte/lib/Files'
-  import Users from 'phosphor-svelte/lib/Users'
-  import GearSix from 'phosphor-svelte/lib/GearSix'
+  import ImageIcon from 'phosphor-svelte/lib/ImageIcon'
+  import FilesIcon from 'phosphor-svelte/lib/FilesIcon'
+  import UsersIcon from 'phosphor-svelte/lib/UsersIcon'
+  import GearSixIcon from 'phosphor-svelte/lib/GearSixIcon'
   import { getLoggedUserContext } from '$lib/context'
 
   const loggedUser = getLoggedUserContext()
@@ -14,27 +14,27 @@
     <div class="flex flex-col gap-0.5">
       <SidebarLink href="/content">
         {#snippet icon()}
-          <Files weight="fill" />
+          <FilesIcon weight="fill" />
         {/snippet}
         Контент
       </SidebarLink>
       <SidebarLink href="/assets">
         {#snippet icon()}
-          <Image weight="fill" />
+          <ImageIcon weight="fill" />
         {/snippet}
         Медіа файли
       </SidebarLink>
       {#if loggedUser.permissions.includes('admin')}
         <SidebarLink href="/users">
           {#snippet icon()}
-            <Users weight="fill" />
+            <UsersIcon weight="fill" />
           {/snippet}
           Користувачі
         </SidebarLink>
       {/if}
       <SidebarLink href="/settings">
         {#snippet icon()}
-          <GearSix weight="fill" />
+          <GearSixIcon weight="fill" />
         {/snippet}
         Налаштування
       </SidebarLink>

--- a/apps/admin/src/routes/(app)/assets/+page.svelte
+++ b/apps/admin/src/routes/(app)/assets/+page.svelte
@@ -4,10 +4,10 @@
   import InputGroup from '$components/InputGroup.svelte'
   import Select from '$components/Select.svelte'
   import SelectOption from '$components/SelectOption.svelte'
-  import MagnifyingGlass from 'phosphor-svelte/lib/MagnifyingGlass'
-  import CloudArrowUp from 'phosphor-svelte/lib/CloudArrowUp'
-  import ArrowUp from 'phosphor-svelte/lib/ArrowUp'
-  import ArrowDown from 'phosphor-svelte/lib/ArrowDown'
+  import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlassIcon'
+  import CloudArrowUpIcon from 'phosphor-svelte/lib/CloudArrowUpIcon'
+  import ArrowUpIcon from 'phosphor-svelte/lib/ArrowUpIcon'
+  import ArrowDownIcon from 'phosphor-svelte/lib/ArrowDownIcon'
   import Alert from '$components/Alert.svelte'
   import AlertTitle from '$components/AlertTitle.svelte'
   import AlertDescription from '$components/AlertDescription.svelte'
@@ -17,7 +17,7 @@
   import AssetItem from '$components/AssetItem.svelte'
   import UploadAssetsDialog from '$components/UploadAssetsDialog.svelte'
   import AssetSkeleton from '$components/Skeletons/AssetSkeleton.svelte'
-  import Trash from 'phosphor-svelte/lib/Trash'
+  import TrashIcon from 'phosphor-svelte/lib/TrashIcon'
   import { useAssets, useDeleteAssets } from '$lib/assets/query'
   import { cn } from '$lib/cn'
   import { sortOptions, DEFAULT_SORT_OPTION } from '$lib/select-options'
@@ -97,7 +97,7 @@
   </h1>
   <Button onclick={() => (isUploadDialogOpen = true)}>
     {#snippet icon()}
-      <CloudArrowUp weight="fill" />
+      <CloudArrowUpIcon weight="fill" />
     {/snippet}
     Завантажити
   </Button>
@@ -107,7 +107,7 @@
   <div class="flex max-w-xl flex-col gap-5 sm:flex-1 sm:flex-row">
     <div class="flex-1">
       <InputGroup>
-        <MagnifyingGlass weight="regular" />
+        <MagnifyingGlassIcon weight="regular" />
         <Input
           placeholder="Пошук&hellip;"
           oninput={debounce(handleSearch)}
@@ -128,9 +128,9 @@
           <SelectOption value={key} label={value.label}>
             {#snippet icon()}
               {#if value.order === 'asc'}
-                <ArrowUp weight="fill" />
+                <ArrowUpIcon weight="fill" />
               {:else}
-                <ArrowDown weight="fill" />
+                <ArrowDownIcon weight="fill" />
               {/if}
             {/snippet}
             {value.label}
@@ -158,7 +158,7 @@
           <div class="flex items-center justify-center gap-4">
             <Button plain onclick={() => (isAlertDialogOpen = true)}>
               {#snippet icon()}
-                <Trash />
+                <TrashIcon />
               {/snippet}
             </Button>
           </div>

--- a/apps/admin/src/routes/(app)/content/[publicationKind]/+page.svelte
+++ b/apps/admin/src/routes/(app)/content/[publicationKind]/+page.svelte
@@ -40,13 +40,13 @@
   import { trimText } from '$lib/trim-text'
   import { usePublicationFilters } from '$lib/use-publication-filters'
   import { PublicationSchema } from '@babyn-yar/schema'
-  import ArrowDown from 'phosphor-svelte/lib/ArrowDown'
-  import ArrowUp from 'phosphor-svelte/lib/ArrowUp'
-  import DotsThree from 'phosphor-svelte/lib/DotsThree'
-  import MagnifyingGlass from 'phosphor-svelte/lib/MagnifyingGlass'
-  import Pencil from 'phosphor-svelte/lib/Pencil'
-  import Plus from 'phosphor-svelte/lib/Plus'
-  import Trash from 'phosphor-svelte/lib/Trash'
+  import ArrowDownIcon from 'phosphor-svelte/lib/ArrowDownIcon'
+  import ArrowUpIcon from 'phosphor-svelte/lib/ArrowUpIcon'
+  import DotsThreeIcon from 'phosphor-svelte/lib/DotsThreeIcon'
+  import MagnifyingGlassIcon from 'phosphor-svelte/lib/MagnifyingGlassIcon'
+  import PencilIcon from 'phosphor-svelte/lib/PencilIcon'
+  import PlusIcon from 'phosphor-svelte/lib/PlusIcon'
+  import TrashIcon from 'phosphor-svelte/lib/TrashIcon'
 
   type Props = {
     data: {
@@ -110,7 +110,7 @@
 <PageHeader {title}>
   <Button href={`/content/${route}/create`}>
     {#snippet icon()}
-      <Plus size={16} />
+      <PlusIcon size={16} />
     {/snippet}
     Cтворити
   </Button>
@@ -121,7 +121,7 @@
     <div class="flex max-w-xl flex-col gap-5 sm:flex-1 sm:flex-row">
       <div class="flex-1">
         <InputGroup>
-          <MagnifyingGlass weight="regular" />
+          <MagnifyingGlassIcon weight="regular" />
           <Input
             placeholder="Пошук&hellip;"
             oninput={debounce(handleSearch)}
@@ -144,9 +144,9 @@
             <SelectOption value={key} label={value.label}>
               {#snippet icon()}
                 {#if value.order === 'asc'}
-                  <ArrowUp weight="fill" />
+                  <ArrowUpIcon weight="fill" />
                 {:else}
-                  <ArrowDown weight="fill" />
+                  <ArrowDownIcon weight="fill" />
                 {/if}
               {/snippet}
               {value.label}
@@ -182,19 +182,19 @@
               <Dropdown>
                 <DropdownButton plain>
                   {#snippet icon()}
-                    <DotsThree />
+                    <DotsThreeIcon />
                   {/snippet}
                 </DropdownButton>
                 <DropdownMenu offset={3}>
                   <DropdownItem onSelect={() => handleEdit(publication)}>
                     {#snippet icon()}
-                      <Pencil weight="fill" />
+                      <PencilIcon weight="fill" />
                     {/snippet}
                     Редагувати
                   </DropdownItem>
                   <DropdownItem onSelect={() => handleShowAlert(publication)}>
                     {#snippet icon()}
-                      <Trash weight="fill" />
+                      <TrashIcon weight="fill" />
                     {/snippet}
                     Видалити
                   </DropdownItem>

--- a/apps/admin/src/routes/(app)/content/[publicationKind]/create/+page.svelte
+++ b/apps/admin/src/routes/(app)/content/[publicationKind]/create/+page.svelte
@@ -10,7 +10,7 @@
   } from '$lib/publications/query'
   import type { PublicationRoute } from '$lib/publications/routes'
   import { PublicationSchema } from '@babyn-yar/schema'
-  import Plus from 'phosphor-svelte/lib/Plus'
+  import PlusIcon from 'phosphor-svelte/lib/PlusIcon'
 
   type Props = {
     data: {
@@ -43,7 +43,7 @@
 <PageHeader title="Новий запис">
   <Button disabled={!canSubmit || isSubmitting} form="record-form">
     {#snippet icon()}
-      <Plus size={16} />
+      <PlusIcon size={16} />
     {/snippet}
     Створити
   </Button>

--- a/apps/admin/src/routes/(app)/content/gallery/+page.svelte
+++ b/apps/admin/src/routes/(app)/content/gallery/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import Plus from 'phosphor-svelte/lib/Plus'
-  import Trash from 'phosphor-svelte/lib/Trash'
+  import PlusIcon from 'phosphor-svelte/lib/PlusIcon'
+  import TrashIcon from 'phosphor-svelte/lib/TrashIcon'
   import {
     useGalleryImages,
     useDeleteGalleryImage,
@@ -54,7 +54,7 @@
                 class="inline-flex items-center justify-center rounded-full border border-red-400/20 bg-red-600 p-2 text-sm font-medium text-red-50 transition-colors hover:bg-red-700 hover:text-red-100"
                 onclick={() => removeImage(image)}
               >
-                <Trash class="h-5 w-5" />
+                <TrashIcon class="h-5 w-5" />
               </button>
             </div>
           </div>
@@ -64,7 +64,7 @@
         class="inline-flex items-center justify-center rounded-md border bg-gray-100 text-gray-400 focus-within:border-sky-400 focus-within:ring focus-within:ring-sky-100 hover:border-sky-400 hover:text-gray-600"
         onclick={handleOpenDialog}
       >
-        <Plus />
+        <PlusIcon />
       </button>
     </div>
   {/if}

--- a/apps/admin/src/routes/(app)/users/+page.svelte
+++ b/apps/admin/src/routes/(app)/users/+page.svelte
@@ -18,10 +18,10 @@
   import AlertTitle from '$components/AlertTitle.svelte'
   import AlertDescription from '$components/AlertDescription.svelte'
   import AlertActions from '$components/AlertActions.svelte'
-  import DotsThree from 'phosphor-svelte/lib/DotsThree'
-  import Pencil from 'phosphor-svelte/lib/Pencil'
-  import Trash from 'phosphor-svelte/lib/Trash'
-  import LockOpen from 'phosphor-svelte/lib/LockOpen'
+  import DotsThreeIcon from 'phosphor-svelte/lib/DotsThreeIcon'
+  import PencilIcon from 'phosphor-svelte/lib/PencilIcon'
+  import TrashIcon from 'phosphor-svelte/lib/TrashIcon'
+  import LockOpenIcon from 'phosphor-svelte/lib/LockOpenIcon'
   import { formatDate } from '$lib/format-date'
   import { useUsers, useDeleteUsers } from '$lib/users/query'
   import type { UserSchema } from '@babyn-yar/schema'
@@ -105,19 +105,19 @@
                 <Dropdown>
                   <DropdownButton plain>
                     {#snippet icon()}
-                      <DotsThree />
+                      <DotsThreeIcon />
                     {/snippet}
                   </DropdownButton>
                   <DropdownMenu offset={3}>
                     <DropdownItem onSelect={() => handleShowEditDialog(user)}>
                       {#snippet icon()}
-                        <Pencil weight="fill" />
+                        <PencilIcon weight="fill" />
                       {/snippet}
                       Редагувати
                     </DropdownItem>
                     <DropdownItem onSelect={() => handleShowAlert(user)}>
                       {#snippet icon()}
-                        <Trash weight="fill" />
+                        <TrashIcon weight="fill" />
                       {/snippet}
                       Видалити
                     </DropdownItem>
@@ -125,7 +125,7 @@
                       onSelect={() => handleShowResetPasswordDialog()}
                     >
                       {#snippet icon()}
-                        <LockOpen weight="fill" />
+                        <LockOpenIcon weight="fill" />
                       {/snippet}
                       Скинути пароль
                     </DropdownItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated admin interface icons throughout assets, content, galleries, users, navigation, forms, and editors for consistent rendering.
  * Preserved existing icon placement, sizing, weights, styling, and interaction behavior.

* **Chores**
  * Streamlined admin checks to run synchronization and type checking without publication tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->