### PR TITLE
api: add route for admin password resets

### DIFF
--- a/apps/api/cmd/api/routes.go
+++ b/apps/api/cmd/api/routes.go
@@ -36,6 +36,7 @@ func (app *application) routes() http.Handler {
 	router.Get("/v1/users/me", app.requireAuthenticatedUser(app.meHandler))
 	router.Get("/v1/users", app.requirePermission("admin", app.listUsersHandler))
 	router.Patch("/v1/users", app.requireAuthenticatedUser(app.updateUserHandler))
+	router.Patch("/v1/users/{id}/password", app.requirePermission("admin", app.resetUserPasswordHandler))
 	router.Delete("/v1/users", app.requirePermission("admin", app.deleteUsersHandler))
 
 	// gallery

--- a/apps/api/cmd/api/users.go
+++ b/apps/api/cmd/api/users.go
@@ -22,6 +22,13 @@ func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
+	v := validator.New()
+	data.ValidatePasswordPlaintext(v, input.Password)
+	if !v.Valid() {
+		app.failedValidationResponse(w, r, v.Errors)
+		return
+	}
+
 	user := &data.User{
 		FullName: input.FullName,
 		Email:    input.Email,
@@ -33,7 +40,6 @@ func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	v := validator.New()
 	if data.ValidateUser(v, user); !v.Valid() {
 		app.failedValidationResponse(w, r, v.Errors)
 		return
@@ -189,6 +195,13 @@ func (app *application) updateUserHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	if input.Password != nil {
+		v := validator.New()
+		data.ValidatePasswordPlaintext(v, *input.Password)
+		if !v.Valid() {
+			app.failedValidationResponse(w, r, v.Errors)
+			return
+		}
+
 		err = user.Password.Set(*input.Password)
 		if err != nil {
 			app.serverErrorResponse(w, r, err)
@@ -219,6 +232,47 @@ func (app *application) updateUserHandler(w http.ResponseWriter, r *http.Request
 	}
 
 	err = app.writeJSON(w, http.StatusOK, envelope{"user": user}, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *application) resetUserPasswordHandler(w http.ResponseWriter, r *http.Request) {
+	userID, err := app.readIDParam(r)
+	if err != nil {
+		app.notFoundResponse(w, r)
+		return
+	}
+
+	var input struct {
+		Password string `json:"password"`
+	}
+
+	err = app.readJSON(w, r, &input)
+	if err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	v := validator.New()
+	data.ValidatePasswordPlaintext(v, input.Password)
+	if !v.Valid() {
+		app.failedValidationResponse(w, r, v.Errors)
+		return
+	}
+
+	err = app.models.Users.UpdatePassword(userID, input.Password)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			app.notFoundResponse(w, r)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	err = app.writeJSON(w, http.StatusOK, envelope{"message": "password successfully reset"}, nil)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 	}

--- a/apps/api/cmd/api/users_integration_test.go
+++ b/apps/api/cmd/api/users_integration_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+
+	"github.com/lex-unix/babyn-yar/internal/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetUserPasswordThroughHTTP(t *testing.T) {
+	testAPI := newAPITest(t)
+	adminClient, _ := authenticatedPublicationClient(
+		t,
+		testAPI,
+		"Password Administrator",
+		"password-admin@example.com",
+	)
+	targetClient, targetID := createAuthenticatedUser(
+		t,
+		testAPI,
+		"Password Target",
+		"password-target@example.com",
+		"publisher",
+	)
+	resetURL := fmt.Sprintf("%s/v1/users/%d/password", testAPI.server.URL, targetID)
+
+	t.Run("authentication is required", func(t *testing.T) {
+		response := publicationJSONRequest(t, http.DefaultClient, http.MethodPatch, resetURL, map[string]string{
+			"password": "new-password",
+		})
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	})
+
+	t.Run("admin permission is required", func(t *testing.T) {
+		response := publicationJSONRequest(t, targetClient, http.MethodPatch, resetURL, map[string]string{
+			"password": "new-password",
+		})
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusForbidden, response.StatusCode)
+	})
+
+	t.Run("password must meet the shared policy", func(t *testing.T) {
+		for _, password := range []string{"short", "пароль123"} {
+			response := publicationJSONRequest(t, adminClient, http.MethodPatch, resetURL, map[string]string{
+				"password": password,
+			})
+			assert.Equal(t, http.StatusUnprocessableEntity, response.StatusCode)
+			response.Body.Close()
+		}
+	})
+
+	t.Run("missing users return not found", func(t *testing.T) {
+		response := publicationJSONRequest(
+			t,
+			adminClient,
+			http.MethodPatch,
+			testAPI.server.URL+"/v1/users/999999/password",
+			map[string]string{"password": "new-password"},
+		)
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	})
+
+	t.Run("an admin can replace the password", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, resetURL, map[string]string{
+			"password": "new-password",
+		})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode)
+
+		var body struct {
+			Message string `json:"message"`
+		}
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		assert.Equal(t, "password successfully reset", body.Message)
+
+		assert.Equal(t, http.StatusUnauthorized, loginStatus(
+			t,
+			testAPI,
+			"password-target@example.com",
+			"password123",
+		))
+		assert.Equal(t, http.StatusOK, loginStatus(
+			t,
+			testAPI,
+			"password-target@example.com",
+			"new-password",
+		))
+	})
+
+	t.Run("existing sessions remain authenticated", func(t *testing.T) {
+		response := publicationJSONRequest(t, targetClient, http.MethodGet, testAPI.server.URL+"/v1/users/me", nil)
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+	})
+}
+
+func createAuthenticatedUser(
+	t *testing.T,
+	testAPI *apiTest,
+	fullName string,
+	email string,
+	permission string,
+) (*http.Client, int64) {
+	t.Helper()
+	user := &data.User{FullName: fullName, Email: email}
+	require.NoError(t, user.Password.Set("password123"))
+	models := data.NewModels(testAPI.db)
+	require.NoError(t, models.Users.Insert(user))
+	require.NoError(t, models.Permissions.AddForUser(user.ID, permission))
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	client := &http.Client{Jar: jar}
+	response := publicationJSONRequest(t, client, http.MethodPost, testAPI.server.URL+"/v1/users/login", map[string]string{
+		"email": email, "password": "password123",
+	})
+	defer response.Body.Close()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	return client, user.ID
+}
+
+func loginStatus(t *testing.T, testAPI *apiTest, email, password string) int {
+	t.Helper()
+	response := publicationJSONRequest(t, http.DefaultClient, http.MethodPost, testAPI.server.URL+"/v1/users/login", map[string]string{
+		"email": email, "password": password,
+	})
+	defer response.Body.Close()
+	return response.StatusCode
+}

--- a/apps/api/internal/data/users.go
+++ b/apps/api/internal/data/users.go
@@ -123,8 +123,18 @@ func ValidateEmail(v *validator.Validator, email string) {
 
 func ValidatePasswordPlaintext(v *validator.Validator, password string) {
 	v.Check(password != "", "password", "must be provided")
-	v.Check(len(password) >= 8, "password", "must be at least 8 bytes long")
-	v.Check(len(password) <= 72, "password", "must not be more than 72 bytes long")
+	v.Check(len(password) >= 8, "password", "must be at least 8 characters long")
+	v.Check(len(password) <= 72, "password", "must not be more than 72 characters long")
+	v.Check(isPrintableASCII(password), "password", "must contain only printable ASCII characters")
+}
+
+func isPrintableASCII(value string) bool {
+	for _, character := range []byte(value) {
+		if character < 0x20 || character > 0x7e {
+			return false
+		}
+	}
+	return true
 }
 
 func ValidateUser(v *validator.Validator, user *User) {
@@ -323,6 +333,32 @@ func (m UserModel) Update(user *User) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (m UserModel) UpdatePassword(userID int64, plaintextPassword string) error {
+	var password password
+	err := password.Set(plaintextPassword)
+	if err != nil {
+		return err
+	}
+
+	query := `
+		UPDATE users
+		SET password_hash = $1, updated_at = now(), version = version + 1
+		WHERE id = $2`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := m.DB.Exec(ctx, query, password.hash, userID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return ErrRecordNotFound
+	}
+
 	return nil
 }
 

--- a/apps/api/internal/data/users_test.go
+++ b/apps/api/internal/data/users_test.go
@@ -1,0 +1,34 @@
+package data
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/lex-unix/babyn-yar/internal/validator"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePasswordPlaintext(t *testing.T) {
+	testCases := []struct {
+		name      string
+		password  string
+		wantValid bool
+	}{
+		{name: "minimum length", password: "12345678", wantValid: true},
+		{name: "printable ASCII with spaces", password: "two words!", wantValid: true},
+		{name: "maximum length", password: strings.Repeat("a", 72), wantValid: true},
+		{name: "too short", password: "1234567", wantValid: false},
+		{name: "too long", password: strings.Repeat("a", 73), wantValid: false},
+		{name: "unicode", password: "пароль123", wantValid: false},
+		{name: "tab", password: "password\t", wantValid: false},
+		{name: "newline", password: "password\n", wantValid: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			v := validator.New()
+			ValidatePasswordPlaintext(v, testCase.password)
+			assert.Equal(t, testCase.wantValid, v.Valid())
+		})
+	}
+}

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set default-list
+
 api_dir := "apps/api"
 main_package := "./cmd/api"
 binary := "api"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an administrator-only option to reset a user’s password by ID.
  * Password resets preserve existing authenticated sessions.
* **Bug Fixes**
  * Added consistent password validation for registration, updates, and resets.
  * Passwords must be 8–72 printable ASCII characters.
  * Improved handling for missing users and reset errors.
* **Chores**
  * Updated the command-line task list to display by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->