### PR TITLE
users: allow admins to edit other users

### DIFF
--- a/apps/admin/src/lib/components/EditUserDialog.svelte
+++ b/apps/admin/src/lib/components/EditUserDialog.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
   import { permissionOptions } from '$lib/select-options'
   import { UserSchema } from '@babyn-yar/schema'
+  import { ResponseError } from '@babyn-yar/api-utils'
+  import { useEditUser } from '$lib/users/query'
   import { createForm } from '@tanstack/svelte-form'
+  import { untrack } from 'svelte'
   import Button from './Button.svelte'
   import Dialog from './Dialog.svelte'
   import DialogActions from './DialogActions.svelte'
@@ -22,14 +25,30 @@
 
   let { open = $bindable(), selectedUser }: Props = $props()
 
+  const editUser = useEditUser()
+
+  function valuesFor(user: UserSchema.User): UserSchema.Edit {
+    return {
+      fullName: user.fullName,
+      email: user.email,
+      permission: user.permissions[0] as 'admin' | 'publisher'
+    }
+  }
+
   const form = createForm(() => ({
-    defaultValues: {
-      fullName: selectedUser.fullName,
-      email: selectedUser.email,
-      permission: selectedUser.permissions[0]
-    } as UserSchema.Edit,
+    defaultValues: valuesFor(selectedUser),
     validators: {
-      onSubmit: UserSchema.Edit
+      onSubmit: UserSchema.Edit,
+      onSubmitAsync: async ({ value }) => {
+        try {
+          await editUser.mutateAsync({ userId: selectedUser.id, input: value })
+        } catch (error) {
+          if (error instanceof ResponseError && error.isFormError()) {
+            return { fields: error.formErrors }
+          }
+          throw error
+        }
+      }
     },
     onSubmit: ({ formApi }) => {
       formApi.reset()
@@ -37,13 +56,20 @@
     }
   }))
 
+  $effect(() => {
+    if (open) {
+      const values = valuesFor(selectedUser)
+      untrack(() => form.reset(values))
+    }
+  })
+
   function handleSubmit(event: SubmitEvent) {
     event.preventDefault()
     form.handleSubmit()
   }
 </script>
 
-<Dialog bind:open onClose={() => form.reset()}>
+<Dialog bind:open onClose={open => !open && form.reset()}>
   <DialogTitle>Редагування користувача</DialogTitle>
   <DialogBody>
     <form id="edit-user-form" onsubmit={handleSubmit} class="space-y-5">

--- a/apps/admin/src/lib/users/query.ts
+++ b/apps/admin/src/lib/users/query.ts
@@ -9,7 +9,7 @@ import { userToasts } from './toast'
 import { authKeys } from '$lib/auth/query'
 import { useUserFilters } from '$lib/use-user-filters'
 import type { UserSchema } from '@babyn-yar/schema'
-import { UserAPI } from '@babyn-yar/api-utils'
+import { ResponseError, UserAPI } from '@babyn-yar/api-utils'
 
 export const userKeys = {
   all: ['users'] as const,
@@ -76,6 +76,25 @@ export function useUpdateSettings() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: userKeys.all })
       queryClient.invalidateQueries({ queryKey: authKeys.me() })
+    }
+  }))
+}
+
+export function useEditUser() {
+  const client = useQueryClient()
+
+  return createMutation(() => ({
+    mutationFn: ({ userId, input }: { userId: number; input: UserSchema.Edit }) =>
+      UserAPI.update(userId, input),
+    onSuccess: () => {
+      client.invalidateQueries({ queryKey: userKeys.all })
+      client.invalidateQueries({ queryKey: authKeys.me() })
+      userToasts.editUserSuccess()
+    },
+    onError: error => {
+      if (!(error instanceof ResponseError && error.isFormError())) {
+        userToasts.editUserError()
+      }
     }
   }))
 }

--- a/apps/admin/src/lib/users/toast.ts
+++ b/apps/admin/src/lib/users/toast.ts
@@ -1,6 +1,14 @@
 import { toast } from 'svelte-sonner'
 
 export const userToasts = {
+  editUserSuccess: () =>
+    toast.success('Зміни збережено', {
+      description: 'Дані користувача було оновлено'
+    }),
+  editUserError: () =>
+    toast.error('Зміни не збережено', {
+      description: 'Не вдалося оновити дані користувача'
+    }),
   updateSettingsSuccess: () =>
     toast.success('Зміни збережено', {
       description: 'Ваші налаштування було збережено'

--- a/apps/api/cmd/api/routes.go
+++ b/apps/api/cmd/api/routes.go
@@ -36,6 +36,7 @@ func (app *application) routes() http.Handler {
 	router.Get("/v1/users/me", app.requireAuthenticatedUser(app.meHandler))
 	router.Get("/v1/users", app.requirePermission("admin", app.listUsersHandler))
 	router.Patch("/v1/users", app.requireAuthenticatedUser(app.updateUserHandler))
+	router.Patch("/v1/users/{id}", app.requirePermission("admin", app.adminUpdateUserHandler))
 	router.Patch("/v1/users/{id}/password", app.requirePermission("admin", app.resetUserPasswordHandler))
 	router.Delete("/v1/users", app.requirePermission("admin", app.deleteUsersHandler))
 

--- a/apps/api/cmd/api/users.go
+++ b/apps/api/cmd/api/users.go
@@ -278,6 +278,73 @@ func (app *application) resetUserPasswordHandler(w http.ResponseWriter, r *http.
 	}
 }
 
+func (app *application) adminUpdateUserHandler(w http.ResponseWriter, r *http.Request) {
+	userID, err := app.readIDParam(r)
+	if err != nil {
+		app.notFoundResponse(w, r)
+		return
+	}
+
+	var input struct {
+		FullName   *string `json:"fullName"`
+		Email      *string `json:"email"`
+		Permission *string `json:"permission"`
+	}
+	if err = app.readJSON(w, r, &input); err != nil {
+		app.badRequestResponse(w, r, err)
+		return
+	}
+
+	v := validator.New()
+	if input.Permission != nil {
+		v.Check(validator.In(*input.Permission, "admin", "publisher"), "permission", "must be admin or publisher")
+	}
+
+	user, err := app.models.Users.GetByID(userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			app.notFoundResponse(w, r)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if input.FullName != nil {
+		user.FullName = *input.FullName
+	}
+	if input.Email != nil {
+		user.Email = *input.Email
+	}
+	data.ValidateUser(v, user)
+	if !v.Valid() {
+		app.failedValidationResponse(w, r, v.Errors)
+		return
+	}
+
+	err = app.models.Users.UpdateByAdmin(user, input.Permission)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrEditConflict):
+			app.editConflictResponse(w, r)
+		case errors.Is(err, data.ErrDuplicateEmail):
+			v.AddError("email", "a user with this email already exists")
+			app.failedValidationResponse(w, r, v.Errors)
+		case errors.Is(err, data.ErrLastAdmin):
+			v.AddError("permission", "at least one administrator must remain")
+			app.failedValidationResponse(w, r, v.Errors)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	if err = app.writeJSON(w, http.StatusOK, envelope{"user": user}, nil); err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
 func (app *application) deleteUsersHandler(w http.ResponseWriter, r *http.Request) {
 	v := validator.New()
 
@@ -295,6 +362,9 @@ func (app *application) deleteUsersHandler(w http.ResponseWriter, r *http.Reques
 		switch {
 		case errors.Is(err, data.ErrRecordNotFound):
 			app.notFoundResponse(w, r)
+		case errors.Is(err, data.ErrLastAdmin):
+			v.AddError("ids", "at least one administrator must remain")
+			app.failedValidationResponse(w, r, v.Errors)
 		default:
 			app.serverErrorResponse(w, r, err)
 		}

--- a/apps/api/cmd/api/users_integration_test.go
+++ b/apps/api/cmd/api/users_integration_test.go
@@ -101,6 +101,193 @@ func TestResetUserPasswordThroughHTTP(t *testing.T) {
 	})
 }
 
+func TestAdminUpdateUserThroughHTTP(t *testing.T) {
+	testAPI := newAPITest(t)
+	adminClient, adminID := authenticatedPublicationClient(
+		t,
+		testAPI,
+		"User Administrator",
+		"user-admin@example.com",
+	)
+	publisherClient, publisherID := createAuthenticatedUser(
+		t,
+		testAPI,
+		"Original Publisher",
+		"original-publisher@example.com",
+		"publisher",
+	)
+	updateURL := fmt.Sprintf("%s/v1/users/%d", testAPI.server.URL, publisherID)
+
+	t.Run("authentication is required", func(t *testing.T) {
+		response := publicationJSONRequest(t, http.DefaultClient, http.MethodPatch, updateURL, map[string]any{
+			"fullName": "Updated Publisher",
+		})
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, response.StatusCode)
+	})
+
+	t.Run("admin permission is required", func(t *testing.T) {
+		response := publicationJSONRequest(t, publisherClient, http.MethodPatch, updateURL, map[string]any{
+			"fullName": "Updated Publisher",
+		})
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusForbidden, response.StatusCode)
+	})
+
+	t.Run("an empty update preserves the user", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, updateURL, map[string]any{})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode)
+
+		var body struct {
+			User data.User `json:"user"`
+		}
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		assert.Equal(t, "Original Publisher", body.User.FullName)
+		assert.Equal(t, "original-publisher@example.com", body.User.Email)
+		assert.Equal(t, data.Permissions{"publisher"}, body.User.Permissions)
+	})
+
+	t.Run("null fields are omitted and invalid values are rejected", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, updateURL, map[string]any{
+			"fullName":   nil,
+			"email":      "not-an-email",
+			"permission": "owner",
+		})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusUnprocessableEntity, response.StatusCode)
+
+		var body struct {
+			Error map[string]string `json:"error"`
+		}
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		assert.NotContains(t, body.Error, "fullName")
+		assert.Contains(t, body.Error, "email")
+		assert.Contains(t, body.Error, "permission")
+	})
+
+	t.Run("missing users return not found", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, testAPI.server.URL+"/v1/users/999999", map[string]any{
+			"fullName": "Missing User",
+		})
+		defer response.Body.Close()
+		assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	})
+
+	t.Run("partial updates preserve omitted fields", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, updateURL, map[string]any{
+			"fullName": "Updated Publisher",
+		})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode)
+
+		var body struct {
+			User data.User `json:"user"`
+		}
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		assert.Equal(t, "Updated Publisher", body.User.FullName)
+		assert.Equal(t, "original-publisher@example.com", body.User.Email)
+		assert.Equal(t, data.Permissions{"publisher"}, body.User.Permissions)
+	})
+
+	t.Run("all editable fields and the single role are replaced", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, updateURL, map[string]any{
+			"fullName":   "Promoted Publisher",
+			"email":      "promoted-publisher@example.com",
+			"permission": "admin",
+		})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode)
+
+		var body struct {
+			User data.User `json:"user"`
+		}
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		assert.Equal(t, "Promoted Publisher", body.User.FullName)
+		assert.Equal(t, "promoted-publisher@example.com", body.User.Email)
+		assert.Equal(t, data.Permissions{"admin"}, body.User.Permissions)
+	})
+
+	t.Run("the last admin cannot be demoted", func(t *testing.T) {
+		response := publicationJSONRequest(t, adminClient, http.MethodPatch, updateURL, map[string]any{
+			"permission": "publisher",
+		})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusOK, response.StatusCode)
+
+		adminURL := fmt.Sprintf("%s/v1/users/%d", testAPI.server.URL, adminID)
+		response = publicationJSONRequest(t, adminClient, http.MethodPatch, adminURL, map[string]any{
+			"permission": "publisher",
+		})
+		defer response.Body.Close()
+		require.Equal(t, http.StatusUnprocessableEntity, response.StatusCode)
+
+		var body struct {
+			Error map[string]string `json:"error"`
+		}
+		require.NoError(t, json.NewDecoder(response.Body).Decode(&body))
+		assert.Contains(t, body.Error, "permission")
+	})
+
+	t.Run("stale versions are rejected", func(t *testing.T) {
+		models := data.NewModels(testAPI.db)
+		user, err := models.Users.GetByID(publisherID)
+		require.NoError(t, err)
+		_, err = testAPI.db.Exec(t.Context(), `UPDATE users SET version = version + 1 WHERE id = $1`, publisherID)
+		require.NoError(t, err)
+
+		user.FullName = "Stale Update"
+		err = models.Users.UpdateByAdmin(user, nil)
+		assert.ErrorIs(t, err, data.ErrEditConflict)
+	})
+}
+
+func TestDeleteUsersPreservesAnAdmin(t *testing.T) {
+	testAPI := newAPITest(t)
+	adminClient, adminID := authenticatedPublicationClient(
+		t,
+		testAPI,
+		"Delete Administrator",
+		"delete-admin@example.com",
+	)
+	_, publisherID := createAuthenticatedUser(
+		t,
+		testAPI,
+		"Delete Publisher",
+		"delete-publisher@example.com",
+		"publisher",
+	)
+
+	deleteURL := fmt.Sprintf("%s/v1/users?ids=%d,%d", testAPI.server.URL, adminID, publisherID)
+	response := publicationJSONRequest(t, adminClient, http.MethodDelete, deleteURL, nil)
+	defer response.Body.Close()
+	require.Equal(t, http.StatusUnprocessableEntity, response.StatusCode)
+
+	models := data.NewModels(testAPI.db)
+	_, err := models.Users.GetByID(adminID)
+	require.NoError(t, err)
+	_, err = models.Users.GetByID(publisherID)
+	require.NoError(t, err, "bulk deletion must be atomic")
+
+	_, secondAdminID := createAuthenticatedUser(
+		t,
+		testAPI,
+		"Remaining Administrator",
+		"remaining-admin@example.com",
+		"admin",
+	)
+	response = publicationJSONRequest(t, adminClient, http.MethodDelete, deleteURL, nil)
+	defer response.Body.Close()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	_, err = models.Users.GetByID(adminID)
+	assert.ErrorIs(t, err, data.ErrRecordNotFound)
+	_, err = models.Users.GetByID(publisherID)
+	assert.ErrorIs(t, err, data.ErrRecordNotFound)
+	_, err = models.Users.GetByID(secondAdminID)
+	require.NoError(t, err)
+}
+
 func createAuthenticatedUser(
 	t *testing.T,
 	testAPI *apiTest,

--- a/apps/api/internal/data/users.go
+++ b/apps/api/internal/data/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -15,6 +16,7 @@ import (
 
 var (
 	ErrDuplicateEmail = errors.New("duplicate email")
+	ErrLastAdmin      = errors.New("at least one admin must remain")
 	AnonymousUser     = &User{}
 )
 
@@ -119,6 +121,8 @@ func SeedInitialUser(db *pgxpool.Pool, fullName, email, password string) error {
 
 func ValidateEmail(v *validator.Validator, email string) {
 	v.Check(email != "", "email", "must be provided")
+	address, err := mail.ParseAddress(email)
+	v.Check(err == nil && address.Address == email, "email", "must be a valid email address")
 }
 
 func ValidatePasswordPlaintext(v *validator.Validator, password string) {
@@ -138,8 +142,8 @@ func isPrintableASCII(value string) bool {
 }
 
 func ValidateUser(v *validator.Validator, user *User) {
-	v.Check(user.FullName != "", "name", "must be provided")
-	v.Check(len(user.FullName) <= 500, "name", "must not be more that 500 bytes long")
+	v.Check(len(user.FullName) >= 3, "fullName", "must be at least 3 characters long")
+	v.Check(len(user.FullName) <= 500, "fullName", "must not be more than 500 bytes long")
 
 	ValidateEmail(v, user.Email)
 
@@ -362,15 +366,107 @@ func (m UserModel) UpdatePassword(userID int64, plaintextPassword string) error 
 	return nil
 }
 
-func (m UserModel) DeleteMultiple(ids []int64) error {
-	query := `
-		DELETE FROM users
-		WHERE id = ANY($1)`
-
+func (m UserModel) UpdateByAdmin(user *User, permission *string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	result, err := m.DB.Exec(ctx, query, ids)
+	tx, err := m.DB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var adminPermissionID int64
+	if permission != nil {
+		// Role-removing mutations lock the same row so concurrent requests cannot
+		// both observe an admin and then remove the last two administrators.
+		err = tx.QueryRow(ctx, `SELECT id FROM permissions WHERE name = 'admin' FOR UPDATE`).Scan(&adminPermissionID)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tx.QueryRow(ctx, `
+		UPDATE users
+		SET full_name = $1, email = $2, updated_at = now(), version = version + 1
+		WHERE id = $3 AND version = $4
+		RETURNING updated_at, version`, user.FullName, user.Email, user.ID, user.Version).Scan(&user.UpdatedAt, &user.Version)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrDuplicateEmail
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrEditConflict
+		}
+		return err
+	}
+
+	if permission != nil {
+		if user.Permissions.Include("admin") && *permission != "admin" {
+			var adminCount int
+			err = tx.QueryRow(ctx, `
+				SELECT count(*)
+				FROM users_permissions
+				WHERE permission_id = $1`, adminPermissionID).Scan(&adminCount)
+			if err != nil {
+				return err
+			}
+			if adminCount <= 1 {
+				return ErrLastAdmin
+			}
+		}
+
+		_, err = tx.Exec(ctx, `DELETE FROM users_permissions WHERE user_id = $1`, user.ID)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO users_permissions (user_id, permission_id)
+			SELECT $1, id FROM permissions WHERE name = $2`, user.ID, *permission)
+		if err != nil {
+			return err
+		}
+		user.Permissions = Permissions{*permission}
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m UserModel) DeleteMultiple(ids []int64) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	tx, err := m.DB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var adminPermissionID int64
+	err = tx.QueryRow(ctx, `SELECT id FROM permissions WHERE name = 'admin' FOR UPDATE`).Scan(&adminPermissionID)
+	if err != nil {
+		return err
+	}
+
+	var adminCount int
+	var deletedAdminCount int
+	err = tx.QueryRow(ctx, `
+		SELECT count(*), count(*) FILTER (WHERE user_id = ANY($2))
+		FROM users_permissions
+		WHERE permission_id = $1`, adminPermissionID, ids).Scan(&adminCount, &deletedAdminCount)
+	if err != nil {
+		return err
+	}
+	if adminCount-deletedAdminCount < 1 {
+		return ErrLastAdmin
+	}
+
+	result, err := tx.Exec(ctx, `DELETE FROM users WHERE id = ANY($1)`, ids)
 	if err != nil {
 		return err
 	}
@@ -381,5 +477,5 @@ func (m UserModel) DeleteMultiple(ids []int64) error {
 		return ErrRecordNotFound
 	}
 
-	return nil
+	return tx.Commit(ctx)
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run --ui tui dev",
+    "dev": "turbo run --ui stream-with-experimental-timestamps dev",
     "dev:plain": "turbo run dev",
     "check": "turbo run check",
     "lint": "turbo run lint",

--- a/packages/api/src/users/index.ts
+++ b/packages/api/src/users/index.ts
@@ -58,6 +58,18 @@ export namespace UserAPI {
     return v.parse(UserSchema.DetailResponse, response)
   }
 
+  export async function update(
+    userId: number,
+    input: Partial<UserSchema.Edit>
+  ) {
+    const response = await fetcher(`${BASE_URL}/${userId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(input)
+    })
+
+    return v.parse(UserSchema.DetailResponse, response)
+  }
+
   export async function resetPassword(
     userId: number,
     input: UserSchema.ResetPasswordRequest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Administrators can edit user names, email addresses, and permissions.
  - User updates now provide success and error notifications.
  - Forms validate changes and display field-specific errors.
  - Updates refresh user and account information automatically.

- **Bug Fixes**
  - Prevented removal or deletion of the final administrator.
  - Added safeguards for duplicate emails, stale updates, invalid data, and missing users.
  - Bulk user deletion now completes atomically, preventing partial changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->